### PR TITLE
docs: fix spelling errors and typos

### DIFF
--- a/packages/docs/src/pages/client-database/index.mdx
+++ b/packages/docs/src/pages/client-database/index.mdx
@@ -8,7 +8,7 @@ Along with reads, every client is able to write to its database and Triplit ensu
 
 ## Client Database
 
-On the client, Triplit keeps your data in two storage areas: an `outbox` and a `cache`. The outbox is a queue of data that is waiting to be sent to the server. The cache is a local copy of the data that has been confirmed to have been recieved by the server.
+On the client, Triplit keeps your data in two storage areas: an `outbox` and a `cache`. The outbox is a queue of data that is waiting to be sent to the server. The cache is a local copy of the data that has been confirmed to have been received by the server.
 
 Although the outbox acts as a queue, it is actually a separate part of the database that is equally queryable. By default, results from the cache and outbox are merged together, however queries can be configured to only return data from the cache (to display only confirmed data) or only return data from the outbox (to denote unconfirmed data).
 
@@ -16,4 +16,4 @@ If a client is offline or is not connected to the remote database for any reason
 
 ## Server Database
 
-The server database provides durable centralized storage for clients and handles propagating writes to other listeneing clients. As well, the server acts as an authoritative figure for data as needed. For example, access control rules are checked on the server and unauthorized updates are rejected and not propagated.
+The server database provides durable centralized storage for clients and handles propagating writes to other listening clients. As well, the server acts as an authoritative figure for data as needed. For example, access control rules are checked on the server and unauthorized updates are rejected and not propagated.

--- a/packages/docs/src/pages/fetching-data/queries.mdx
+++ b/packages/docs/src/pages/fetching-data/queries.mdx
@@ -115,7 +115,7 @@ const query = client
   ]);
 ```
 
-You may use dot notation to filter by attirbutes of a record.
+You may use dot notation to filter by attributes of a record.
 
 ```typescript
 const query = client.query('users').where('address.city', '=', 'New York');
@@ -144,7 +144,7 @@ Clauses can be passed to `order` as a single clause or an array of clauses:
 - `.order(['created_at', 'DESC'])`
 - `.order([['created_at', 'DESC']])`
 
-You may use dot notation to order by attirbutes of a record.
+You may use dot notation to order by attributes of a record.
 
 ```typescript
 const query = client.query('users').order('address.city', 'ASC');

--- a/packages/docs/src/pages/fetching-data/subscriptions.mdx
+++ b/packages/docs/src/pages/fetching-data/subscriptions.mdx
@@ -25,4 +25,4 @@ const unsubscribe = client.subscribe(
 );
 ```
 
-If a subscription query fails on the server then syncing for that query will stop. However, the subscription will remain active and updates to the local database will still be available. As well, the syncing of other queries will not be impacted. Although you will not recieve updates from the server, updates that you make via [mutations](/updating-data) will be sent.
+If a subscription query fails on the server then syncing for that query will stop. However, the subscription will remain active and updates to the local database will still be available. As well, the syncing of other queries will not be impacted. Although you will not receive updates from the server, updates that you make via [mutations](/updating-data) will be sent.

--- a/packages/docs/src/pages/guides/auth.mdx
+++ b/packages/docs/src/pages/guides/auth.mdx
@@ -4,7 +4,7 @@
 
 Many apps require a way to authenticate users. Triplit is configured to look for certain [variables](/fetching-data/queries#variables) to determine who is making a request. This information is then used to inform the [authorization](#authorization) process.
 
-Authentication itself should be handled by an authentication service outside of Triplit. This could be a third-party service like [Auth0](https://auth0.com/), [Firebase Auth](https://firebase.google.com/products/auth), [AWS Cognito](https://aws.amazon.com/cognito/), [Supabse Auth](https://supabase.com/docs/guides/auth), etc or a custom service built by your team. The authentication service should provide a way to generate a token with Triplit specific claims that can be used to identify the user.
+Authentication itself should be handled by an authentication service outside of Triplit. This could be a third-party service like [Auth0](https://auth0.com/), [Firebase Auth](https://firebase.google.com/products/auth), [AWS Cognito](https://aws.amazon.com/cognito/), [Supabase Auth](https://supabase.com/docs/guides/auth), etc or a custom service built by your team. The authentication service should provide a way to generate a token with Triplit specific claims that can be used to identify the user.
 
 A token must have the following claims:
 

--- a/packages/docs/src/pages/guides/local-development.mdx
+++ b/packages/docs/src/pages/guides/local-development.mdx
@@ -4,7 +4,7 @@ Although you can connect directly to a managed or self hosted instance of a remo
 
 ## Install the CLI
 
-If you havent already, install the Triplit CLI and initialize a project. You can find instructions for doing so [here](/getting-started).
+If you haven't already, install the Triplit CLI and initialize a project. You can find instructions for doing so [here](/getting-started).
 
 ## Start Triplit services
 
@@ -19,7 +19,7 @@ By default this will start the following services:
 - Triplit Console, running at port 6542
 - Triplit Database server, running at port 6543
 
-And prints a usable Serivce API key and Anon API key for connecting to the database.
+And prints a usable Service API key and Anon API key for connecting to the database.
 
 ## Additional environment variables
 

--- a/packages/docs/src/pages/guides/migrations.mdx
+++ b/packages/docs/src/pages/guides/migrations.mdx
@@ -109,7 +109,7 @@ Migrate down to a specific migration:
 triplit migrate down <version>
 ```
 
-This command applies all down migrations to your server until you reach the specified verison. You may optionally provide a version to migrate to.
+This command applies all down migrations to your server until you reach the specified version. You may optionally provide a version to migrate to.
 
 ## Passing migrations to the client
 

--- a/packages/docs/src/pages/index.mdx
+++ b/packages/docs/src/pages/index.mdx
@@ -27,6 +27,6 @@ These features are required for any application that aims to be fast, responsive
 
 **Triplit is developer friendly.** Triplit takes care to be easy to use. It gets rid of the headaches of building a realtime system at all levels of the stack, and is potentially the only backend service you need for an app. Additionally, it is designed to work well with Typescript applications, ensuring your type definitions remain up to date as your schema evolves.
 
-**Triplit is open source.** Triplit may be self-hosted, so you can run it on your own infrastructure. Triplit also provides [Triplit Cloud](/guides/triplit-cloud) - a hosted service that managages upgrades, auto-scaling, and offers technical support.
+**Triplit is open source.** Triplit may be self-hosted, so you can run it on your own infrastructure. Triplit also provides [Triplit Cloud](/guides/triplit-cloud) - a hosted service that manages upgrades, auto-scaling, and offers technical support.
 
 The rest of the docs will explain how to use Triplit in your application.

--- a/packages/docs/src/pages/updating-data.mdx
+++ b/packages/docs/src/pages/updating-data.mdx
@@ -64,7 +64,7 @@ await client.transact((tx) => {
 
 ## Error and success handling
 
-Mutations are first run on Triplit's local cache "optimistically", returning a promise. If the optimistic mutation is successful, the promise will resolve with the id of the transaction. If the optimistic mutation fails, the promise will reject with an error. So you can handle optimisitc updates with standard promise handling. For example:
+Mutations are first run on Triplit's local cache "optimistically", returning a promise. If the optimistic mutation is successful, the promise will resolve with the id of the transaction. If the optimistic mutation fails, the promise will reject with an error. So you can handle optimistic updates with standard promise handling. For example:
 
 ```typescript
 try {
@@ -99,4 +99,4 @@ client.syncEngine.onTxFailure(txId, (e) => {
 });
 ```
 
-Tripit's API attempts to give you the flexibility to handle errors in various ways. For example, you could choose to retry a transaction a certain number of times before rolling it back. Or you could choose to retry a transaction only if it failed due to a network error.
+Triplit's API attempts to give you the flexibility to handle errors in various ways. For example, you could choose to retry a transaction a certain number of times before rolling it back. Or you could choose to retry a transaction only if it failed due to a network error.


### PR DESCRIPTION
Hello! Just fixing a couple typos and spelling errors I saw when going through the docs. Please let me know if this PR requires any other changes or formatting fixes. 

Thanks for developing such a neat service!