### PR TITLE
Use `dotenv-expand`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,6 +44,7 @@
     "chokidar": "^3.5.3",
     "degit": "^2.8.4",
     "dotenv": "^16.3.1",
+    "dotenv-expand": "^10.0.0",
     "ink": "^4.4.0",
     "jsondiffpatch": "^0.5.0",
     "jsonwebtoken": "^9.0.2",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import dotenv from 'dotenv';
-dotenv.config();
+import dotenvExpand from 'dotenv-expand';
+dotenvExpand.expand(dotenv.config());
 import {
   bgGreenBright,
   bold,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4505,6 +4505,7 @@ __metadata:
     chokidar: ^3.5.3
     degit: ^2.8.4
     dotenv: ^16.3.1
+    dotenv-expand: ^10.0.0
     ink: ^4.4.0
     jsondiffpatch: ^0.5.0
     jsonwebtoken: ^9.0.2
@@ -8297,6 +8298,13 @@ __metadata:
   version: 3.0.5
   resolution: "dompurify@npm:3.0.5"
   checksum: 2d9421570c833ce26ce7022955241749b646d41e8bf453f42ede9f22d0e98af482cedb7dfbf8129419eb48b351c1d677a08fc9f1cd91836ce7f6c1807a0676b2
+  languageName: node
+  linkType: hard
+
+"dotenv-expand@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "dotenv-expand@npm:10.0.0"
+  checksum: 2a38b470efe0abcb1ac8490421a55e1d764dc9440fd220942bce40965074f3fb00b585f4346020cb0f0f219966ee6b4ee5023458b3e2953fe5b3214de1b314ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
With [dotenv-expand](https://www.npmjs.com/package/dotenv-expand), Your CLI can allow developers to set `.env` in a more friendly way.
This package is used in most major libraries and frameworks such as Vite and Next.js.

In [this commit](https://github.com/aspen-cloud/triplit/commit/4f05c0292c0f983f2c10c6468020a48c58012866#diff-a1ba810dadd232a9f004db1447600c2025d9797b64724b36a63af4ff40344db6R15) you set **TRIPLIT_JWT_SECRET** to `$NEXTAUTH_SECRET`. 
You might have expected it to be replaced with `test`, but the CLI will interpret it as the string `"$NEXTAUTH_SECRET"`.

I would appreciate it if you could review my PR. 
And thank you for creating such an excellent library!!!