### PR TITLE
Docs - Fixing typo in self-hosting page

### DIFF
--- a/packages/docs/src/pages/self-hosting.mdx
+++ b/packages/docs/src/pages/self-hosting.mdx
@@ -4,7 +4,7 @@ description: Learn how to self host Triplit using Docker, and how to deploy it t
 
 # Self-hosting Triplit
 
-To enable sync, you need to run a Triplit servezr. The server is a Node.js application that talks to various Triplit clients over WebSockets and HTTP.
+To enable sync, you need to run a Triplit server. The server is a Node.js application that talks to various Triplit clients over WebSockets and HTTP.
 
 You have several options for running the server:
 
@@ -85,7 +85,7 @@ const serviceKey = jwt.sign(
 );
 ```
 
-For more complicate authentication schemes, refer to our [authentication guide](/auth).
+For more complicated authentication schemes, refer to our [authentication guide](/auth).
 
 ### `EXTERNAL_JWT_SECRET` (optional)
 


### PR DESCRIPTION
- Fixed a typo
- A minor wording change, "complicate" to "complicated"