### PR TITLE
Add Typescript type for schema to avoid Errors

### DIFF
--- a/packages/docs/src/pages/react-tutorial.mdx
+++ b/packages/docs/src/pages/react-tutorial.mdx
@@ -76,7 +76,7 @@ We're going to set up a [schema](/schemas) for the Todos app in the `./triplit/s
 ```ts filename="./triplit/schema.ts" copy
 import { Schema as S, ClientSchema } from '@triplit/client';
 
-export const schema = {
+export const schema: ClientSchema = {
   todos: {
     schema: S.Schema({
       id: S.Id(),


### PR DESCRIPTION
Without this, we get a typescript error:

```
TS2742: The inferred type of schema cannot be named without a reference to
../node_modules/.pnpm/@triplit+db@0.3.54_react@18.3.1/node_modules/@triplit/db/dist/types/data-types/value
. This is likely not portable. A type annotation is necessary.
TS2742: The inferred type of schema cannot be named without a reference to
.pnpm/@triplit+db@0.3.54_react@18.3.1/node_modules/@triplit/db
. This is likely not portable. A type annotation is necessary.
```

Adding this fixes that without any changes.