### PR TITLE
docs: use appropriate example terms

### DIFF
--- a/packages/docs/src/pages/client/query/subquery.mdx
+++ b/packages/docs/src/pages/client/query/subquery.mdx
@@ -8,7 +8,7 @@ import { Callout } from 'nextra/components';
 
 The `subquery` method can be used to add an ad-hoc query on related data to an entity. [Relations](/schemas/relations) are formalized subqueries that are defined in the schema. But a `subquery` is a way to add any nested query to a Triplit query at runtime, regardless of relations in the schema.
 
-For example, the following schema has two collections, `users` and `blogs`, where each todo has a `user_id` attribute that references a user:
+For example, the following schema has two collections, `users` and `blogs`, where each blog post has a `author` attribute that references a user:
 
 ```typescript
 const schema = {
@@ -43,7 +43,7 @@ const query = client
   .build();
 ```
 
-The subquery method takes three arguments: the key to store the result of the subquery, the subquery itself, and the cardinality of the relation. The cardinality can be either `one` or `many` and if none is provided it will default to `many`. In the example above, the cardinality is `many` because a user can have many blogs. If the cardinality is `one`, the subquery will return a single result. The following query will return the last todo created by the user:
+The subquery method takes three arguments: the key to store the result of the subquery, the subquery itself, and the cardinality of the relation. The cardinality can be either `one` or `many` and if none is provided it will default to `many`. In the example above, the cardinality is `many` because a user can have many blogs. If the cardinality is `one`, the subquery will return a single result. The following query will return the text of the most recent blog item created by the user:
 
 ```typescript
 const query = client

--- a/packages/docs/src/pages/client/query/subquery.mdx
+++ b/packages/docs/src/pages/client/query/subquery.mdx
@@ -8,7 +8,7 @@ import { Callout } from 'nextra/components';
 
 The `subquery` method can be used to add an ad-hoc query on related data to an entity. [Relations](/schemas/relations) are formalized subqueries that are defined in the schema. But a `subquery` is a way to add any nested query to a Triplit query at runtime, regardless of relations in the schema.
 
-For example, the following schema has two collections, `users` and `blogs`, where each blog post has a `author` attribute that references a user:
+For example, the following schema has two collections, `users` and `blogs`, where each blog post has an `author` attribute that references a user:
 
 ```typescript
 const schema = {


### PR DESCRIPTION
e.g. the `todo` was leftover from the previous template example.