### PR TITLE
feat: add triplitJsonFromJsonSchema

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -96,4 +96,5 @@ export * from './data-types/index.js';
 export * from './data-types/types/index.js';
 export * from './data-types/constants.js';
 export * from './schema/export/index.js';
+export * from './schema/import/index.js';
 export * from './utils/generator.js';

--- a/packages/db/src/schema/export/json-schema/export.ts
+++ b/packages/db/src/schema/export/json-schema/export.ts
@@ -52,6 +52,7 @@ export function exportSchemaAsJSONSchema(
 ): JSONSchema7 | undefined {
   //
   if (!schema) return undefined;
+
   const collectionsListJsonSchema: Record<string, JSONSchema7> = {};
 
   const triplitSchemaJsonData = schemaToJSON({
@@ -59,11 +60,16 @@ export function exportSchemaAsJSONSchema(
     version: 0,
   });
 
-  for (const collectionKey in triplitSchemaJsonData?.collections) {
+  // copy and work on duplicate to keep original object unchanged
+  const duplicateOfTriplitSchemaJsonData = structuredClone(
+    triplitSchemaJsonData
+  );
+
+  for (const collectionKey in duplicateOfTriplitSchemaJsonData?.collections) {
     //
     const collectionJsonSchema: JSONSchema7 =
       transformTriplitJsonDataInJsonSchema(
-        triplitSchemaJsonData,
+        duplicateOfTriplitSchemaJsonData,
         collectionKey
       );
 

--- a/packages/db/src/schema/export/json-schema/transform-funcs.ts
+++ b/packages/db/src/schema/export/json-schema/transform-funcs.ts
@@ -59,22 +59,18 @@ function transformNullable(object: any) {
 }
 
 function transformDefault(object: any) {
-  if (object?.options?.default) {
+// if (object?.options?.default != null) {
     // we set the default, though JSON Schema notes that it should be
     // only used for documentation / example values, not as form default
-    if (
-      typeof object?.options?.default === 'string' ||
-      typeof object?.options?.default === 'number'
-    ) {
+    if (typeof object?.options?.default !== 'function') {
       object.default = object.options.default;
-      return;
-    }
+          }
 
     if (object?.options?.default?.func != null) {
-      // Handle  triplit's special cases: 'now' and 'uuid'
+      // Handle triplit's special cases: 'now' and 'uuid'
       object.default = object.options.default.func;
-    }
-  }
+      }
+// }
 }
 
 function transformEnum(object: any) {

--- a/packages/db/src/schema/export/json-schema/transform-funcs.ts
+++ b/packages/db/src/schema/export/json-schema/transform-funcs.ts
@@ -59,18 +59,18 @@ function transformNullable(object: any) {
 }
 
 function transformDefault(object: any) {
-// if (object?.options?.default != null) {
-    // we set the default, though JSON Schema notes that it should be
-    // only used for documentation / example values, not as form default
-    if (typeof object?.options?.default !== 'function') {
-      object.default = object.options.default;
-          }
+  // if (object?.options?.default != null) {
+  // we set the default, though JSON Schema notes that it should be
+  // only used for documentation / example values, not as form default
+  if (typeof object?.options?.default !== 'function') {
+    object.default = object.options.default;
+  }
 
-    if (object?.options?.default?.func != null) {
-      // Handle triplit's special cases: 'now' and 'uuid'
-      object.default = object.options.default.func;
-      }
-// }
+  if (object?.options?.default?.func != null) {
+    // Handle triplit's special cases: 'now' and 'uuid'
+    object.default = object.options.default.func;
+  }
+  // }
 }
 
 function transformEnum(object: any) {
@@ -83,18 +83,28 @@ export function transformPropertiesOptionalToRequired(object: any) {
   // To indicate optional fields, triplit uses an optional array, while
   // JSON schema uses the inverse concept and uses a "required" array field
 
+  return tranformKeysRequirementsContext(object, 'optional', 'required');
+}
+
+export function tranformKeysRequirementsContext(
+  object: any,
+  from = 'optional',
+  towards = 'required'
+) {
   if (object.properties != null) {
     const allKeys = Object.keys(object.properties);
-    const triplitOptionalKeys = object?.optional ?? [];
+    const specialKeys = object?.[from] ?? [];
 
-    const diff = allKeys.filter((item) => !triplitOptionalKeys?.includes(item));
+    const diff = allKeys.filter((item) => !specialKeys?.includes(item));
+    // ensure sorting order, else tests fail even if the same items
+    diff.sort();
 
     // object.required = structuredClone(diff);
     if (diff.length > 0) {
-      object.required = structuredClone(diff);
+      object[towards] = structuredClone(diff);
     }
 
-    delete object?.optional;
+    delete object?.[from];
   }
 
   return object;

--- a/packages/db/src/schema/export/json-schema/transform-funcs.ts
+++ b/packages/db/src/schema/export/json-schema/transform-funcs.ts
@@ -67,10 +67,12 @@ function transformDefault(object: any) {
       typeof object?.options?.default === 'number'
     ) {
       object.default = object.options.default;
-    } else {
-      // Handle complex default values (e.g., functions) if needed
-      // triplit uses: default: { func: 'uuid', args: null }
-      // Currently, we're not handling these cases
+      return;
+    }
+
+    if (object?.options?.default?.func != null) {
+      // Handle  triplit's special cases: 'now' and 'uuid'
+      object.default = object.options.default.func;
     }
   }
 }

--- a/packages/db/src/schema/export/json-schema/transform-funcs.ts
+++ b/packages/db/src/schema/export/json-schema/transform-funcs.ts
@@ -34,47 +34,6 @@ export function deleteRelationFields(
   return object;
 }
 
-// export function transformOptions(object: any, overlyingObj?: any) {
-//   // --- guard from undefined/null
-//   if (object.options == null) return object;
-
-//   // --- nullable
-//   if (object?.options?.nullable === true) {
-//     // nullable values are indicated as type: ["null"] in JSON schema
-//     if (Array.isArray(object.type) === false) {
-//       object.type = [object.type, 'null'];
-//     } else {
-//       // normally triplit's schema should just be a string, but
-//       // just in case it changes to allow array of types
-//       object.type.push('null');
-//     }
-//   }
-//   // --- default
-//   if (object?.options?.default) {
-//     // we set the default, though JSON Schema notes that it should be
-//     // only used for documentation / example values, not as form default
-//     if (
-//       typeof object?.options?.default === 'string' ||
-//       typeof object?.options?.default === 'number'
-//     ) {
-//       object.default = String(object.options.default);
-//     } else {
-//       // we do nothing
-//       // as if it's object to define a function
-//       // triplit uses: default: { func: 'uuid', args: null }
-//     }
-//   }
-
-//   // --- enum
-//   if (object?.options?.enum != null) {
-//     object.enum = object?.options?.enum;
-//   }
-
-//   delete object?.options;
-
-//   return object;
-// }
-
 export function transformOptions(object: any, overlyingObj?: any) {
   if (object.options == null) return object;
 
@@ -107,7 +66,7 @@ function transformDefault(object: any) {
       typeof object?.options?.default === 'string' ||
       typeof object?.options?.default === 'number'
     ) {
-      object.default = String(object.options.default);
+      object.default = object.options.default;
     } else {
       // Handle complex default values (e.g., functions) if needed
       // triplit uses: default: { func: 'uuid', args: null }

--- a/packages/db/src/schema/import/index.ts
+++ b/packages/db/src/schema/import/index.ts
@@ -1,0 +1,1 @@
+export * from './json-schema/triplit-json-from-json-schema.js';

--- a/packages/db/src/schema/import/json-schema/invert-transform-functions.ts
+++ b/packages/db/src/schema/import/json-schema/invert-transform-functions.ts
@@ -1,0 +1,511 @@
+import { JSONSchema7 } from 'json-schema';
+import { tranformKeysRequirementsContext } from '../../export/json-schema/transform-funcs';
+
+/**
+ * @param object the (sub)object transforms are applied to
+ * @param useJsonSchemaDefault whether the jsonSchema's default value should be used to fill in default - jsonSchema's default is per spec only meant to be used for examples in doc generation, but might be used otherwise depending on generator
+ **/
+export function invertTransformations(
+  object: JSONSchema7,
+  useJsonSchemaDefault = true
+): any {
+  let result: any = { ...object };
+  // const omittedConstraints: omittedConstraints = [];
+
+  result = checkJsonDataCompatibility(result);
+  result = omitConstraints(result);
+
+  result = transform(result, useJsonSchemaDefault);
+
+  if (result.properties) {
+    for (const [key, value] of Object.entries(result.properties)) {
+      result.properties[key] = invertTransformations(value as JSONSchema7);
+    }
+  }
+
+  // Remove any undefined properties
+  Object.keys(result).forEach(
+    (key) => result[key] === undefined && delete result[key]
+  );
+
+  return result;
+}
+
+function checkJsonDataCompatibility(result: any) {
+  result = checkDateFormats(result);
+  result = checkConst(result);
+  result = checkObjectHasProperties(result);
+  result = checkCombinations(result);
+  result = checkArray(result);
+  result = checkRef(result);
+
+  return result;
+}
+
+function omitConstraints(
+  result: any,
+  omittedConstraints: omittedConstraints = []
+) {
+  result = checkPropPatternsAndDependencies(result);
+  result = checkStringConstraints(result);
+  result = checkNumberConstraints(result);
+  result = checkArrayConstraints(result);
+  result = checkObjectConstraints(result);
+  result = checkConditionals(result);
+
+  return result;
+}
+
+function transform(result: any, useJsonSchemaDefault = true) {
+  // order is significant !
+  result = transformInteger(result);
+  result = transformNull(result);
+  result = invertTransformRecord(result);
+  result = invertTransformSet(result);
+  result = invertTransformOptions(result, useJsonSchemaDefault);
+  result = invertTransformDate(result);
+  result = transformPropertiesRequiredToOptional(result);
+  result = handleIdKey(result);
+
+  return result;
+}
+
+// ========================================================================
+// Throw Error Heuristic
+// errors are only thrown if there's no type counterpart in triplit
+
+// We only throw error if we can't convert the type to a data type in triplit
+// as long as it's only validation rules/constraints, they are simply removed
+// ========================================================================
+
+export function checkDateFormats(object: any): any {
+  if (object.format === 'time' || object.format === 'duration') {
+    throw new Error(
+      'date formats "time" and "duration" are not supported by Triplit - please remove them from your JSON data'
+    );
+  }
+  return object;
+}
+
+export function checkArray(object: any): any {
+  if (object.type !== 'array') return object;
+
+  if (object.uniqueItems !== true) {
+    throw new Error(
+      'Only array types with uniqueItems = true are supported, since Triplit only yet supports set type'
+    );
+  }
+
+  if (
+    Array.isArray(object.items) === true ||
+    object.items.type === 'object' ||
+    object.unevaluatedItems != null ||
+    object.prefixItems != null
+  ) {
+    throw new Error(
+      "Arrays that hold objects or tuples are not supported, as Triplit's Set can only have primitives - please remove them from your JSON data"
+    );
+  }
+
+  return object;
+}
+
+export function checkObjectHasProperties(object: any): any {
+  if (object.type === 'object' && object.properties == null) {
+    throw new Error(
+      'each type object requires a properties field for Triplit Schema to process it'
+    );
+  }
+  return object;
+}
+
+export function checkConst(object: any): any {
+  if (object.type != null && object.const != null) {
+    throw new Error(
+      'const type is not supported by Triplit - please remove them from your JSON data'
+    );
+  }
+  return object;
+}
+
+// ========================================================================
+// Constraints deletion
+// constraints are simply removed since we assume they are enforced by
+// application logic using the jsonSchema in a validator
+// ========================================================================
+
+type omittedConstraints = { name: string; object: string; desc: string }[];
+
+export function checkRef(object: any): any {
+  if (object.$ref) {
+    throw new Error(
+      "'$ref' are not supported by Triplit - please remove them from your JSON data"
+    );
+  }
+
+  return object;
+}
+
+function omitProperties(
+  object: any,
+  propertiesToDelete: string[],
+  // omittedConstraints: omittedConstraints,
+  desc: string
+) {
+  // omittedConstraints.push({
+  //   name: String(property),
+  //   object: JSON.stringify(object),
+  //   desc: desc,
+  // });
+  for (const property of propertiesToDelete) {
+    delete object[property];
+  }
+  console.warn(
+    `'omittedConstraints:'
+    ${propertiesToDelete.join(', ')}
+    in
+    ${JSON.stringify(object)}
+    \n ${desc}`
+  );
+  // console.warn(
+  //   `Constraints/Validation rules that are not natively supported on Triplit's db schema have been omited.
+  //   As long as you use the jsonSchema to enforce the schema in your application code, this should not be an issue.
+  //   You can check the omitted constraints in the 'omittedConstraints' return field.`
+  // );
+}
+
+export function checkStringConstraints(object: any): any {
+  if (object.type !== 'string') return object;
+
+  if (
+    object.maxLength != null ||
+    object.minLength != null ||
+    object.pattern != null
+  ) {
+    // throw new Error(
+    //   'JSON string constraints (" 6.3. Validation Keywords for Strings ") are not supported by Triplit - please remove them from your JSON data'
+    // );
+    omitProperties(
+      object,
+      ['maxLength', 'minLength', 'pattern'],
+      'JSON string constraints (" 6.3. Validation Keywords for Strings ") are not supported by Triplit - please remove them from your JSON data'
+    );
+  }
+  return object;
+}
+
+export function checkNumberConstraints(object: any): any {
+  if (object.type !== 'number' && object.type !== 'integer') return object;
+
+  if (
+    object.multipleOf != null ||
+    object.maximum != null ||
+    object.exclusiveMaximum != null ||
+    object.minimum != null ||
+    object.exclusiveMinimum != null
+  ) {
+    // throw new Error(
+    //   'JSON number constraints ("6.2. Validation Keywords for Numeric Instances (number and integer)") are not supported by Triplit - please remove them from your JSON data'
+    // );
+
+    omitProperties(
+      object,
+      [
+        'multipleOf',
+        'maximum',
+        'exclusiveMaximum',
+        'minimum',
+        'exclusiveMinimum',
+      ],
+      'JSON number constraints ("6.2. Validation Keywords for Numeric Instances (number and integer)") are not supported by Triplit - please remove them from your JSON data'
+    );
+  }
+  return object;
+}
+
+export function checkArrayConstraints(object: any): any {
+  if (object.type !== 'array') return object;
+
+  if (
+    object.maxItems != null ||
+    object.minItems != null ||
+    object.contains != null ||
+    object.maxContains != null
+  ) {
+    // throw new Error(
+    //   'JSON array constraints ("6.4. Validation Keywords for Arrays") are not supported by Triplit - please remove them from your JSON data'
+    // );
+    omitProperties(
+      object,
+      ['maxItems', 'minItems', 'contains', 'maxContains'],
+      'JSON array constraints ("6.4. Validation Keywords for Arrays") are not supported by Triplit - please remove them from your JSON data'
+    );
+  }
+
+  return object;
+}
+
+export function checkObjectConstraints(object: any): any {
+  if (object.type !== 'object') return object;
+
+  if (
+    object.minProperties != null ||
+    object.maxProperties != null ||
+    object.dependentRequired != null ||
+    object.dependentSchemas != null
+  ) {
+    omitProperties(
+      object,
+      [
+        'minProperties',
+        'maxProperties',
+        'dependentRequired',
+        'dependentSchemas',
+      ],
+      'JSON object constraints ("6.5. Validation Keywords for Objects") are not supported by Triplit - please remove them from your JSON data'
+    );
+    // throw new Error(
+    //   'JSON object constraints ("6.5. Validation Keywords for Objects") are not supported by Triplit - please remove them from your JSON data'
+    // );
+  }
+  return object;
+}
+
+export function checkPropPatternsAndDependencies(object: any): any {
+  if (object.type !== 'object') return object;
+
+  if (object.patternProperties) {
+    omitProperties(
+      object,
+      ['patternProperties'],
+      "'patternProperties' are not supported by Triplit - please remove them from your JSON data"
+    );
+    // throw new Error(
+    //   "'patternProperties' are not supported by Triplit - please remove them from your JSON data"
+    // );
+  }
+
+  if (object.dependencies) {
+    omitProperties(
+      object,
+      ['dependencies'],
+      "'dependencies' are not supported by Triplit - please remove them from your JSON data"
+    );
+  }
+
+  return object;
+}
+
+export function checkConditionals(object: any): any {
+  if (
+    (object.if && object?.if?.type == null) ||
+    (object.then && object?.then?.type == null) ||
+    (object.else && object?.else?.type == null)
+  ) {
+    omitProperties(
+      object,
+      ['if', 'then', 'else'],
+      "Conditionals like 'if / then / else' are not supported by Triplit - please remove them from your JSON data"
+    );
+
+    // throw new Error(
+    //   "Conditionals like 'if / then / else' are not supported by Triplit - please remove them from your JSON data"
+    // );
+  }
+
+  return object;
+}
+
+export function checkCombinations(object: any): any {
+  if (
+    (object.allOf && Array.isArray(object.allOf)) ||
+    (object.anyOf && Array.isArray(object.anyOf)) ||
+    (object.oneOf && Array.isArray(object.oneOf)) ||
+    (object.not && Array.isArray(object.not))
+  ) {
+    throw new Error(
+      "Combinations like 'allOf / anyOf / oneOf / not' are not supported by Triplit - please remove them from your JSON data"
+    );
+  }
+
+  return object;
+}
+
+// ========================================================================
+// Transform functions
+// ========================================================================
+
+export function handleIdKey(object: any): any {
+  // transform to the format that triplit uses for id keys
+  // only way to detect it on this object level
+  if (object?.options?.default?.func === 'uuid') {
+    object.options.nullable = false;
+    // object.options = {
+    //   default: {
+    //     func: 'uuid',
+    //     args: null,
+    //   },
+    //   nullable: false,
+    // };
+  }
+
+  return object;
+}
+
+export function transformNull(object: any): any {
+  if (object.type === 'null') {
+    return {
+      ...object,
+      type: 'string',
+      options: { nullable: true, default: null },
+    };
+  }
+  return object;
+}
+
+export function invertTransformDate(object: any): any {
+  if (object.format === 'date-time' || object.format === 'date') {
+    // format is enough, no need to check for:
+    // object.type === 'string' && object.type.includes("string")
+    // (if nullable will be ['string','null'])
+    const { format, type, ...rest } = object;
+
+    return { ...rest, type: 'date' };
+  }
+  return object;
+}
+
+export function transformInteger(object: any): any {
+  if (object?.items?.type === 'integer') {
+    object.items.type = 'number';
+  }
+  if (object.type === 'integer') {
+    return { ...object, type: 'number' };
+  }
+  return object;
+}
+
+export function invertTransformRecord(object: any): any {
+  if (object.type === 'object') {
+    return { ...object, type: 'record' };
+  }
+  return object;
+}
+
+export function invertTransformSet(object: any): any {
+  if (
+    object.uniqueItems === true &&
+    (object.type === 'array' || object.type.includes('array'))
+  ) {
+    // const { uniqueItems, ...rest } = object;
+    const isDateItems = object?.items?.format === 'date-time';
+    const itemsType = isDateItems ? 'date' : object?.items?.type;
+    const itemOptions = Object.create({});
+    const itemEnums = object?.items?.enum;
+
+    const isNullable = object.type.includes('null');
+
+    delete object.uniqueItems;
+
+    // populate object
+    object.type = 'set';
+    // options always present on triplit set
+    if (!object.options) {
+      object.options = {};
+
+      if (isNullable) {
+        object.options.nullable = isNullable;
+      }
+    }
+
+    handleDefault(object.items, itemOptions, true);
+
+    // move enums
+    if (itemEnums) {
+      itemOptions.enum = itemEnums;
+    }
+
+    object.items = { type: itemsType ?? '', options: { ...itemOptions } };
+    // const result = { ...rest, type: 'set' };
+  }
+  return object;
+}
+
+interface SchemaObject {
+  type: string | string[];
+  default?: any;
+  enum?: any[];
+  options?: any;
+}
+
+interface OptionsObject {
+  nullable?: boolean;
+  default?: any;
+  enum?: any[];
+}
+
+export function invertTransformOptions(
+  object: SchemaObject,
+  useJsonSchemaDefault = true
+): SchemaObject {
+  const result: SchemaObject = { ...object };
+  const options: OptionsObject = { ...result.options };
+
+  handleNullableType(result, options);
+  handleDefault(result, options, useJsonSchemaDefault);
+  handleEnum(result, options);
+
+  // fill options
+  // triplit object primitives have always an options obj present, even if empty
+  // but record types have not
+  result.options =
+    Object.keys(options).length > 0 || result.type !== 'record'
+      ? options
+      : undefined;
+
+  return result;
+}
+
+function handleNullableType(
+  result: SchemaObject,
+  options: OptionsObject
+): void {
+  if (Array.isArray(result.type) && result.type.includes('null')) {
+    options.nullable = true;
+    result.type = result.type.filter((t: string) => t !== 'null')[0];
+  }
+}
+
+function handleDefault(
+  result: SchemaObject,
+  options: OptionsObject,
+  useJsonSchemaDefault: boolean
+): void {
+  if (result.default != null) {
+    if (useJsonSchemaDefault) {
+      options.default = result.default;
+    }
+    // overwrite if special condition
+    if (options.default === 'uuid' || options.default === 'now') {
+      options.default = {
+        func: result.default,
+        args: null,
+      };
+    }
+
+    delete result.default;
+  }
+}
+
+function handleEnum(result: SchemaObject, options: OptionsObject): void {
+  if (result.enum != null) {
+    options.enum = result.enum;
+    delete result.enum;
+  }
+}
+
+export function transformPropertiesRequiredToOptional(object: any) {
+  // To indicate optional fields, triplit uses an optional array, while
+  // JSON schema uses the inverse concept and uses a "required" array field
+  return tranformKeysRequirementsContext(object, 'required', 'optional');
+}

--- a/packages/db/src/schema/import/json-schema/invert-transform-functions.ts
+++ b/packages/db/src/schema/import/json-schema/invert-transform-functions.ts
@@ -1,5 +1,5 @@
 import { JSONSchema7 } from 'json-schema';
-import { tranformKeysRequirementsContext } from '../../export/json-schema/transform-funcs';
+import { tranformKeysRequirementsContext } from '../../export/json-schema/transform-funcs.js';
 
 /**
  * @param object the (sub)object transforms are applied to

--- a/packages/db/src/schema/import/json-schema/triplit-json-from-json-schema.ts
+++ b/packages/db/src/schema/import/json-schema/triplit-json-from-json-schema.ts
@@ -1,6 +1,6 @@
 import { JSONSchema7 } from 'json-schema';
 import { invertTransformations } from './invert-transform-functions.js';
-import { SchemaDefinition } from 'packages/db/src/data-types/serialization.js';
+import { SchemaDefinition } from '../../types/serialization.js';
 import { JSONToSchema } from '../../schema.js';
 
 export function triplitJsonFromJsonSchema(

--- a/packages/db/src/schema/import/json-schema/triplit-json-from-json-schema.ts
+++ b/packages/db/src/schema/import/json-schema/triplit-json-from-json-schema.ts
@@ -1,0 +1,61 @@
+import { JSONSchema7 } from 'json-schema';
+import { invertTransformations } from './invert-transform-functions.js';
+import { SchemaDefinition } from 'packages/db/src/data-types/serialization.js';
+import { JSONToSchema } from '../../schema.js';
+
+export function triplitJsonFromJsonSchema(
+  jsonSchema: JSONSchema7,
+  defaultFillIn = true
+): SchemaDefinition | undefined {
+  // work on copy to keep original immutable
+  const jsonSchemaCopy = structuredClone(jsonSchema);
+
+  const collections: Record<string, any> = {};
+
+  for (const [collectionName, collectionSchema] of Object.entries(
+    jsonSchemaCopy.properties || {}
+  )) {
+    const transformedData = invertTransformations(
+      collectionSchema as JSONSchema7,
+      defaultFillIn
+    );
+
+    collections[collectionName] = {
+      //
+      schema: transformedData,
+    };
+  }
+
+  // check if omittedConstraints, if so add a console.warn
+  // console.warn('omittedConstraints:');
+  // console.warn(
+  //   `Constraints/Validation rules that are not natively supported on Triplit's db schema have been omited.
+  //   As long as you use the jsonSchema to enforce the schema in your application code, this should not be an issue.
+  //   You can check the omitted constraints in the 'omittedConstraints' return field.`
+  // );
+
+  validateTriplitSchema(collections);
+
+  return {
+    collections,
+    version: 0,
+  };
+}
+
+function validateTriplitSchema(collectionsToValidate: Record<string, any>) {
+  // as recommended by triplit team member
+  // to validate, try converting into a triplit JS Object
+  try {
+    JSONToSchema({
+      collections: collectionsToValidate,
+      version: 0,
+    });
+  } catch (err) {
+    const customError: Error & { details?: any } = new Error(
+      'Triplit couldnt parse your transformed data. Catch this error and check the details object. Maybe there are objects that are empty or without type',
+      { cause: err }
+    );
+    customError.details = { transformedData: collectionsToValidate };
+    throw customError;
+  }
+}

--- a/packages/db/test/db/export/export.spec.ts
+++ b/packages/db/test/db/export/export.spec.ts
@@ -42,6 +42,7 @@ describe('Full JSON Compliance Test', () => {
       type: 'object',
       properties: {
         id: {
+          default: 'uuid',
           type: 'string',
         },
         boolean: {
@@ -90,6 +91,7 @@ describe('Full JSON Compliance Test', () => {
           type: 'object',
           properties: {
             id: {
+              default: 'uuid',
               type: 'string',
             },
             boolean: {

--- a/packages/db/test/db/export/transform-functions.spec.ts
+++ b/packages/db/test/db/export/transform-functions.spec.ts
@@ -43,6 +43,20 @@ describe('transformOptions', () => {
     });
   });
 
+  test('should correctly set boolean default', () => {
+    const input = {
+      type: 'boolean',
+      options: {
+        default: false,
+      },
+    };
+    const output = transformOptions(input);
+    expect(output).toEqual({
+      type: 'boolean',
+      default: false,
+    });
+  });
+
   test('null added correctly if nullable true', () => {
     const input = {
       type: 'string',
@@ -243,7 +257,7 @@ describe('Test all Transforms together', () => {
           },
         },
       },
-      required: ['stringEnum', 'set_stringEnum'],
+      required: ['set_stringEnum', 'stringEnum'],
     };
 
     transformFunctions.forEach((transformFunc) => {
@@ -356,12 +370,12 @@ describe('Test all Transforms together', () => {
         },
       },
       required: [
-        'recordType',
-        'obj',
         'id',
+        'obj',
+        'recordType',
         'set_number',
-        'stringEnum',
         'set_stringEnum',
+        'stringEnum',
       ],
     };
 

--- a/packages/db/test/db/export/transform-functions.spec.ts
+++ b/packages/db/test/db/export/transform-functions.spec.ts
@@ -74,7 +74,31 @@ describe('transformOptions', () => {
       },
     };
     const output = transformOptions(input);
-    expect(output).toEqual({ type: ['string', 'null'] });
+    expect(output).toEqual({ type: ['string', 'null'], default: 'uuid' });
+  });
+
+  test('handle special Triplit default values: uuid', () => {
+    const input = {
+      type: 'string',
+      options: {
+        nullable: true,
+        default: { func: 'uuid', args: null },
+      },
+    };
+    const output = transformOptions(input);
+    expect(output).toEqual({ type: ['string', 'null'], default: 'uuid' });
+  });
+
+  test('handle special Triplit default values: now', () => {
+    const input = {
+      type: 'string',
+      options: {
+        nullable: true,
+        default: { func: 'now', args: null },
+      },
+    };
+    const output = transformOptions(input);
+    expect(output).toEqual({ type: ['string', 'null'], default: 'now' });
   });
 });
 
@@ -297,6 +321,7 @@ describe('Test all Transforms together', () => {
         obj: { type: 'string', format: 'date-time' },
         id: {
           type: ['string', 'null'],
+          default: 'uuid',
         },
 
         set_string: {
@@ -366,6 +391,7 @@ describe('Test all Transforms together', () => {
       properties: {
         id: {
           type: ['string', 'null'],
+          default: 'uuid',
         },
         recordType: { value: 1, obj: { type: 'object' } },
       },

--- a/packages/db/test/db/import/json-schema/exampleTestOfjsonSchemaFromZodSchema.ts
+++ b/packages/db/test/db/import/json-schema/exampleTestOfjsonSchemaFromZodSchema.ts
@@ -1,0 +1,238 @@
+// from https://github.com/StefanTerdell/zod-to-json-schema/blob/master/test/allParsers.test.ts
+// but elements that throw are removed
+
+export const exampleTestOfjsonSchemaFromZodSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  properties: {
+    array: {
+      type: 'array',
+      uniqueItems: true,
+      items: {
+        type: 'string',
+      },
+    },
+    arrayMin: {
+      type: 'array',
+      uniqueItems: true,
+      minItems: 1,
+      items: {
+        type: 'string',
+      },
+    },
+    arrayMax: {
+      type: 'array',
+      uniqueItems: true,
+      maxItems: 1,
+      items: {
+        type: 'string',
+      },
+    },
+    arrayMinMax: {
+      type: 'array',
+      uniqueItems: true,
+      minItems: 1,
+      maxItems: 1,
+      items: {
+        type: 'string',
+      },
+    },
+    bigInt: {
+      type: 'integer',
+      format: 'int64',
+    },
+    boolean: {
+      type: 'boolean',
+    },
+    date: {
+      type: 'string',
+      format: 'date-time',
+    },
+    // default: {
+    //   default: 42,
+    // },
+    effectRefine: {
+      type: 'string',
+    },
+    effectTransform: {
+      type: 'string',
+    },
+    effectPreprocess: {
+      type: 'string',
+    },
+    enum: {
+      type: 'string',
+      enum: ['hej', 'svejs'],
+    },
+    literal: {
+      type: 'string',
+    },
+    nativeEnum: {
+      type: 'number',
+      enum: [0, 1, 2],
+    },
+    null: {
+      type: 'null',
+    },
+    nullablePrimitive: {
+      type: ['string', 'null'],
+    },
+    number: {
+      type: 'number',
+    },
+    numberGt: {
+      type: 'number',
+      exclusiveMinimum: 1,
+    },
+    numberLt: {
+      type: 'number',
+      exclusiveMaximum: 1,
+    },
+    numberGtLt: {
+      type: 'number',
+      exclusiveMinimum: 1,
+      exclusiveMaximum: 1,
+    },
+    numberGte: {
+      type: 'number',
+      minimum: 1,
+    },
+    numberLte: {
+      type: 'number',
+      maximum: 1,
+    },
+    numberGteLte: {
+      type: 'number',
+      minimum: 1,
+      maximum: 1,
+    },
+    numberMultipleOf: {
+      type: 'number',
+      multipleOf: 2,
+    },
+    numberInt: {
+      type: 'integer',
+    },
+    objectPasstrough: {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'string',
+        },
+        bar: {
+          type: 'number',
+        },
+      },
+      required: ['foo'],
+      additionalProperties: true,
+    },
+    objectCatchall: {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'string',
+        },
+        bar: {
+          type: 'number',
+        },
+      },
+      required: ['foo'],
+      additionalProperties: {
+        type: 'boolean',
+      },
+    },
+    objectStrict: {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'string',
+        },
+        bar: {
+          type: 'number',
+        },
+      },
+      required: ['foo'],
+      additionalProperties: false,
+    },
+    objectStrip: {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'string',
+        },
+        bar: {
+          type: 'number',
+        },
+      },
+      required: ['foo'],
+      additionalProperties: false,
+    },
+    promise: {
+      type: 'string',
+    },
+    recordStringBoolean: {
+      type: 'object',
+      properties: {},
+      additionalProperties: {
+        type: 'boolean',
+      },
+    },
+    set: {
+      type: 'array',
+      uniqueItems: true,
+      items: {
+        type: 'string',
+      },
+    },
+    string: {
+      type: 'string',
+    },
+    stringMin: {
+      type: 'string',
+      minLength: 1,
+    },
+    stringMax: {
+      type: 'string',
+      maxLength: 1,
+    },
+    stringEmail: {
+      type: 'string',
+      format: 'email',
+    },
+    stringEmoji: {
+      type: 'string',
+      pattern: '^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$',
+    },
+    stringUrl: {
+      type: 'string',
+      format: 'uri',
+    },
+    stringUuid: {
+      type: 'string',
+      format: 'uuid',
+    },
+    stringRegEx: {
+      type: 'string',
+      pattern: 'abc',
+    },
+    stringCuid: {
+      type: 'string',
+      pattern: '^[cC][^\\s-]{8,}$',
+    },
+    unionPrimitives: {
+      type: ['string', 'number', 'boolean', 'integer', 'null'],
+    },
+    unionPrimitiveLiterals: {
+      type: ['number', 'string', 'null', 'boolean'],
+      enum: [123, 'abc', null, true],
+    },
+    // TODO: write test for empty objects?
+    // unknown: {},
+  },
+  additionalProperties: false,
+  // add test? no, this is not valid json schema
+  // default: {
+  //   string: 'hello',
+  // },
+  description: 'watup',
+};

--- a/packages/db/test/db/import/json-schema/invert-transform-functions.spec.ts
+++ b/packages/db/test/db/import/json-schema/invert-transform-functions.spec.ts
@@ -1,0 +1,635 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  invertTransformDate,
+  invertTransformRecord,
+  invertTransformSet,
+  invertTransformOptions,
+  invertTransformations,
+  handleIdKey,
+  transformPropertiesRequiredToOptional,
+} from '../../../../src/schema/import/json-schema/invert-transform-functions';
+
+describe('invertTransformDate', () => {
+  test('inverts only string type with date-time format', () => {
+    const input = { type: 'string', format: 'date-time' };
+    const output = invertTransformDate(input);
+    expect(output).toEqual({ type: 'date' });
+  });
+
+  test('does not modify non-date-time fields', () => {
+    const input = { type: 'string' };
+    const output = invertTransformDate(input);
+    expect(output).toEqual({ type: 'string' });
+  });
+});
+
+describe('invertTransformRecord', () => {
+  test('inverts only object type to record type', () => {
+    const input = { type: 'object' };
+    const output = invertTransformRecord(input);
+    expect(output).toEqual({ type: 'record' });
+  });
+
+  test('does not modify non-object types', () => {
+    const input = { type: 'string' };
+    const output = invertTransformRecord(input);
+    expect(output).toEqual({ type: 'string' });
+  });
+});
+
+describe('invertTransformSet', () => {
+  test('inverts array type with uniqueItems to set', () => {
+    const input = {
+      type: 'array',
+      items: {
+        type: 'number',
+      },
+      uniqueItems: true,
+    };
+    const output = invertTransformSet(input);
+    expect(output).toEqual({
+      type: 'set',
+      items: {
+        type: 'number',
+        options: {},
+      },
+      options: {},
+    });
+  });
+
+  test('inverts array type with nullable items', () => {
+    const input = {
+      type: ['array', 'null'],
+      items: {
+        type: 'number',
+      },
+      uniqueItems: true,
+    };
+    const output = invertTransformSet(input);
+    expect(output).toEqual({
+      type: 'set',
+      items: {
+        type: 'number',
+        options: {},
+      },
+      options: {
+        nullable: true,
+      },
+    });
+  });
+
+  test('set of string enum', () => {
+    const input = {
+      type: 'array',
+      items: {
+        type: 'string',
+        enum: ['a', 'b', 'c'],
+      },
+      uniqueItems: true,
+    };
+
+    const output = invertTransformSet(input);
+    expect(output).toEqual({
+      type: 'set',
+      items: {
+        type: 'string',
+        options: {
+          enum: ['a', 'b', 'c'],
+        },
+      },
+      options: {},
+    });
+  });
+
+  test('set of string enum with default', () => {
+    const input = {
+      type: 'array',
+      items: {
+        type: 'string',
+        default: 'a',
+        enum: ['a', 'b', 'c'],
+      },
+      uniqueItems: true,
+    };
+    let output = invertTransformSet(input);
+    output = invertTransformOptions(input);
+    expect(output).toEqual({
+      type: 'set',
+      items: {
+        type: 'string',
+        options: {
+          default: 'a',
+          enum: ['a', 'b', 'c'],
+        },
+      },
+      options: {},
+    });
+  });
+
+  test('does not modify non-set arrays', () => {
+    const input = { type: 'array' };
+    const output = invertTransformSet(input);
+    expect(output).toEqual({ type: 'array' });
+  });
+
+  // test('inverts nested items', () => {
+  //   const input = {
+  //     type: 'array',
+  //     uniqueItems: true,
+  //     items: { type: 'string', format: 'date-time' },
+  //   };
+  //   const output = invertTransformSet(input);
+  //   expect(output).toEqual({
+  //     type: 'set',
+  //     items: {
+  //       type: 'date',
+  //       options: {},
+  //     },
+  //   });
+  // });
+});
+
+describe('default handling', () => {
+  test('fill in default if set to true/none', () => {
+    const input = {
+      type: 'string',
+      default: 'Only example text for Documentation as intended by JSON schema',
+    };
+
+    const output = invertTransformOptions(input);
+    expect(output).toEqual({
+      type: 'string',
+      options: {
+        default:
+          'Only example text for Documentation as intended by JSON schema',
+      },
+    });
+  });
+
+  test('do not fill in default if set to false', () => {
+    const input = {
+      type: 'string',
+      default: 'Only example text for Documentation as intended by JSON schema',
+    };
+
+    const output = invertTransformOptions(input, false);
+    expect(output).toEqual({
+      type: 'string',
+      options: {},
+    });
+  });
+
+  describe('respect default of type number', () => {
+    test('have number type as default, not string', () => {
+      const input = { type: 'number', default: 1 };
+
+      // @ts-ignore otherwise json schema type error, but ok here since
+      // we only need to check if type is correct
+      const output = invertTransformations(input);
+
+      expect(output).toEqual({
+        type: 'number',
+        options: {
+          default: 1,
+        },
+      });
+    });
+  });
+});
+
+describe('Triplit special key handling', () => {
+  // test('"id" key should be transformed to triplit JSON data id automatically (or skipped if an option like that is added)', () => {
+  //   const input = {
+  //     id: {
+  //       type: 'string',
+  //     },
+  //   };
+
+  //   const output = handleIdKey(input);
+
+  //   expect(output).toEqual({
+  //     id: {
+  //       type: 'string',
+  //       options: {
+  //         nullable: false,
+  //         default: {
+  //           func: 'uuid',
+  //           args: null,
+  //         },
+  //       },
+  //     },
+  //   });
+  // });
+
+  test('uuid in default as special signal to convert to Triplit special function', () => {
+    const input = {
+      type: 'string',
+      default: 'uuid',
+    };
+
+    // @ts-ignore
+    const output = invertTransformations(input);
+
+    expect(output).toEqual({
+      type: 'string',
+      options: {
+        default: {
+          func: 'uuid',
+          args: null,
+        },
+        nullable: false,
+      },
+    });
+  });
+
+  test('now in default as special signal to convert to Triplit special function', () => {
+    const input = {
+      type: 'string',
+      format: 'date-time',
+      default: 'now',
+    };
+
+    // @ts-ignore
+    const output = invertTransformations(input);
+
+    expect(output).toEqual({
+      type: 'date',
+      options: {
+        default: {
+          func: 'now',
+          args: null,
+        },
+      },
+    });
+  });
+
+  // test('now in large collection', () => {
+  //   const input = {
+  //     type: 'object',
+  //     properties: {
+  //       id: {
+  //         type: 'string',
+  //         default: 'uuid',
+  //       },
+  //       boolean: {
+  //         type: 'boolean',
+  //       },
+  //       string: {
+  //         type: 'string',
+  //         default: 'a string',
+  //       },
+  //       stringEnum: {
+  //         type: 'string',
+  //         default: 'a',
+  //         enum: ['a', 'b', 'c'],
+  //       },
+  //       stringEnumOptional: {
+  //         type: 'string',
+  //         enum: ['a', 'b', 'c'],
+  //       },
+  //       number: {
+  //         type: 'number',
+  //         default: 1,
+  //       },
+  //       date: {
+  //         type: 'string',
+  //         format: 'date-time',
+  //         default: 'now',
+  //       },
+  //       set_string: {
+  //         type: 'array',
+  //         items: {
+  //           type: 'string',
+  //           default: '1',
+  //         },
+  //         uniqueItems: true,
+  //       },
+  //       set_number: {
+  //         type: 'array',
+  //         items: {
+  //           type: 'number',
+  //           default: 1,
+  //         },
+  //         uniqueItems: true,
+  //       },
+  //       set_boolean: {
+  //         type: 'array',
+  //         items: {
+  //           type: 'boolean',
+  //         },
+  //         uniqueItems: true,
+  //       },
+  //       set_date: {
+  //         type: 'array',
+  //         items: {
+  //           type: 'string',
+  //           format: 'date-time',
+  //           default: 'now',
+  //         },
+  //         uniqueItems: true,
+  //       },
+  //       set_stringEnum: {
+  //         type: 'array',
+  //         items: {
+  //           type: 'string',
+  //           default: 'a',
+  //           enum: ['a', 'b', 'c'],
+  //         },
+  //         uniqueItems: true,
+  //       },
+  //       object: {
+  //         type: 'object',
+  //         properties: {
+  //           id: {
+  //             type: 'string',
+  //             default: 'uuid',
+  //           },
+  //           boolean: {
+  //             type: 'boolean',
+  //           },
+  //           string: {
+  //             type: 'string',
+  //             default: 'a string',
+  //           },
+  //           number: {
+  //             type: 'number',
+  //             default: 1,
+  //           },
+  //           date: {
+  //             type: 'string',
+  //             format: 'date-time',
+  //             default: 'now',
+  //           },
+  //           set_number: {
+  //             type: 'array',
+  //             items: {
+  //               type: 'number',
+  //               default: 1,
+  //             },
+  //             uniqueItems: true,
+  //           },
+  //           set_boolean: {
+  //             type: 'array',
+  //             items: {
+  //               type: 'boolean',
+  //             },
+  //             uniqueItems: true,
+  //           },
+  //           set_date: {
+  //             type: 'array',
+  //             items: {
+  //               type: 'string',
+  //               format: 'date-time',
+  //               default: 'now',
+  //             },
+  //             uniqueItems: true,
+  //           },
+  //           set_string: {
+  //             type: 'array',
+  //             items: {
+  //               type: 'string',
+  //               default: '1',
+  //             },
+  //             uniqueItems: true,
+  //           },
+  //           set_stringEnum: {
+  //             type: 'array',
+  //             items: {
+  //               type: 'string',
+  //               default: 'a',
+  //               enum: ['a', 'b', 'c'],
+  //             },
+  //             uniqueItems: true,
+  //           },
+  //         },
+  //         required: [
+  //           'boolean',
+  //           'date',
+  //           'id',
+  //           'number',
+  //           'set_boolean',
+  //           'set_date',
+  //           'set_number',
+  //           'set_string',
+  //           'set_stringEnum',
+  //           'string',
+  //         ],
+  //       },
+  //     },
+  //     required: [
+  //       'boolean',
+  //       'date',
+  //       'id',
+  //       'number',
+  //       'object',
+  //       'set_boolean',
+  //       'set_date',
+  //       'set_number',
+  //       'set_string',
+  //       'set_stringEnum',
+  //       'string',
+  //       'stringEnum',
+  //     ],
+  //   };
+
+  //   // @ts-ignore
+  //   const output = invertTransformations(input);
+  //   debugger;
+  //   expect(output).toEqual({
+  //     type: 'date',
+  //     options: {
+  //       default: {
+  //         func: 'now',
+  //         args: null,
+  //       },
+  //     },
+  //   });
+  // });
+  //
+});
+
+describe('invertTransformOptions', () => {
+  test('options object in TriplitSchema needs always be present, even if empty', () => {
+    const input = {
+      type: 'string',
+    };
+    const output = invertTransformOptions(input);
+    expect(output).toEqual({
+      type: 'string',
+      options: {},
+    });
+  });
+
+  test('moves default to options', () => {
+    const input = {
+      type: 'string',
+      default: 'Hello World',
+    };
+    const output = invertTransformOptions(input);
+    expect(output).toEqual({
+      type: 'string',
+      options: {
+        default: 'Hello World',
+      },
+    });
+  });
+
+  test('adds nullable option if type includes null', () => {
+    const input = { type: ['string', 'null'] };
+    const output = invertTransformOptions(input);
+    expect(output).toEqual({
+      type: 'string',
+      options: {
+        nullable: true,
+      },
+    });
+  });
+
+  test('moves enum to options', () => {
+    const input = {
+      type: 'string',
+      enum: ['a', 'b', 'c'],
+    };
+    const output = invertTransformOptions(input);
+    expect(output).toEqual({
+      type: 'string',
+      options: {
+        enum: ['a', 'b', 'c'],
+      },
+    });
+  });
+
+  test('combines multiple options', () => {
+    const input = {
+      type: ['string', 'null'],
+      default: 'Hello World',
+      enum: ['Hello World', 'Goodbye'],
+    };
+    const output = invertTransformOptions(input);
+    expect(output).toEqual({
+      type: 'string',
+      options: {
+        nullable: true,
+        default: 'Hello World',
+        enum: ['Hello World', 'Goodbye'],
+      },
+    });
+  });
+});
+
+describe('tramsform required to optional', () => {
+  test('add optional array for fields not marked as required', () => {
+    //
+    const input = {
+      properties: {
+        check: { type: 'boolean ' },
+        field: { type: 'string' },
+        numbers: { type: 'number' },
+        set_number: {
+          type: 'set',
+          items: { type: 'number', options: {} },
+          options: {},
+        },
+      },
+      required: ['check', 'set_number'],
+    };
+
+    const output = transformPropertiesRequiredToOptional(input);
+
+    expect(output).toEqual({
+      properties: {
+        check: { type: 'boolean ' },
+        field: { type: 'string' },
+        numbers: { type: 'number' },
+        set_number: {
+          type: 'set',
+          items: { type: 'number', options: {} },
+          options: {},
+        },
+      },
+      optional: ['field', 'numbers'],
+    });
+  });
+
+  test('does not modify object without a properties field', () => {
+    //
+    const input = { stringField: 'Hello World', numbers: [1, 2, 3] };
+
+    const output = transformPropertiesRequiredToOptional(input);
+
+    expect(output).toEqual({
+      stringField: 'Hello World',
+      numbers: [1, 2, 3],
+    });
+  });
+});
+
+// TODO: do a full invertTransformations on data
+// describe('invertTransformations', () => {
+//   test('applies all invert transformations', () => {
+
+// const input = {
+//   title: 'JSON Schema of Triplit Schema',
+//   description: 'version 0',
+//   type: 'object',
+//   properties: {
+//     numberTest: {
+//       type: 'number',
+//       default: 1,
+//     },
+//   },
+// };
+
+//     const input = {
+//       type: 'object',
+//       properties: {
+//         date: { type: 'string', format: 'date-time' },
+//         set: { type: 'array', uniqueItems: true, items: { type: 'string' } },
+//         enum: { type: ['string', 'null'], enum: ['a', 'b', 'c'], default: 'a' },
+//       },
+//     };
+//     const output = invertTransformations(input);
+//     expect(output).toEqual({
+//       type: 'record',
+//       properties: {
+//         date: { type: 'date' },
+//         set: { type: 'set', items: { type: 'string' } },
+//         enum: {
+//           type: 'string',
+//           options: {
+//             nullable: true,
+//             enum: ['a', 'b', 'c'],
+//             default: 'a',
+//           },
+//         },
+//       },
+//     });
+//   });
+
+//   test('handles nested structures', () => {
+//     const input = {
+//       type: 'object',
+//       properties: {
+//         nested: {
+//           type: 'object',
+//           properties: {
+//             date: { type: 'string', format: 'date-time' },
+//           },
+//         },
+//       },
+//     };
+//     const output = invertTransformations(input);
+//     expect(output).toEqual({
+//       type: 'record',
+//       properties: {
+//         nested: {
+//           type: 'record',
+//           properties: {
+//             date: { type: 'date' },
+//           },
+//         },
+//       },
+//     });
+//   });
+// });

--- a/packages/db/test/db/import/json-schema/triplit-json-from-json-schema.spec.ts
+++ b/packages/db/test/db/import/json-schema/triplit-json-from-json-schema.spec.ts
@@ -1,0 +1,1288 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { triplitJsonFromJsonSchema } from '../../../../src/schema/import/json-schema/triplit-json-from-json-schema';
+import { exportSchemaAsJSONSchema } from '../../../../src/schema/export/json-schema/export';
+import { schema as exhaustiveTestTriplitSchema } from '../../export/exhaustive-test-schema';
+
+import { schemaToJSON } from '../../../../src/schema/export';
+import { JSONSchema7 } from 'json-schema';
+import { exampleTestOfjsonSchemaFromZodSchema } from './exampleTestOfjsonSchemaFromZodSchema';
+
+describe('Essential Tests', () => {
+  test('All Collections: convert Triplit schema back and forth, plus validation', () => {
+    // 0. convert the triplit schema into triplit's own json format
+    // so it is comparable
+    const originalTriplitJson = schemaToJSON({
+      collections: exhaustiveTestTriplitSchema,
+      version: 0,
+    });
+
+    // 0. filter out the relation fields, since they are only for inter-linking
+    // fields/collections and json schema has no representation for it
+    const originalTriplitJson_WithoutRelationFields =
+      duplicateWithoutAncestorsWithKey(originalTriplitJson, 'cardinality');
+
+    // 1. export the Triplit Schema as JSON Schema
+    const jsonSchema = exportSchemaAsJSONSchema(exhaustiveTestTriplitSchema);
+    if (!jsonSchema) throw new Error('Schema not exported');
+
+    // 2. Then reverse and import the JSON Schema again as Triplit JSON schema
+    const importedTriplitJsonFormat = triplitJsonFromJsonSchema(jsonSchema);
+
+    // 3. check if it the same as the original
+    expect(importedTriplitJsonFormat).toEqual(
+      originalTriplitJson_WithoutRelationFields
+    );
+  });
+
+  test('patternProperties and dependencies should be omitted', () => {
+    //
+    const jsonSchemaComprensiveTest = {
+      title: 'Comprehensive Test Schema',
+      description:
+        'A schema to test various features of JSON Schema validation',
+      type: 'object',
+      properties: {
+        objectTests: {
+          type: 'object',
+          properties: {
+            objectWithPatternProperties: {
+              type: 'object',
+              properties: {},
+              dependencies: {},
+              dependentRequired: { credit_card: ['billing_address'] },
+              dependentSchemas: {
+                credit_card: {
+                  properties: { billing_address: { type: 'string' } },
+                  required: ['billing_address'],
+                },
+              },
+              patternProperties: {
+                '^S_': {
+                  type: 'string',
+                },
+                '^I_': {
+                  type: 'integer',
+                },
+              },
+              additionalProperties: false,
+            },
+          },
+        },
+      },
+    };
+
+    const output = triplitJsonFromJsonSchema(
+      jsonSchemaComprensiveTest as JSONSchema7
+    );
+
+    expect(output).toEqual({
+      collections: {
+        objectTests: {
+          schema: {
+            type: 'record',
+            properties: {
+              objectWithPatternProperties: {
+                type: 'record',
+                properties: {},
+                additionalProperties: false,
+              },
+            },
+            optional: ['objectWithPatternProperties'],
+          },
+        },
+      },
+      version: 0,
+    });
+    // .toThrowError(
+    //   "'patternProperties' are not supported by Triplit - please remove them from your JSON data"
+    // );
+  });
+
+  test('defaultFillIn=false should not copy over default values', () => {
+    //
+    const jsonSchemaComprensiveTest = {
+      title: 'Comprehensive Test Schema',
+      description:
+        'A schema to test various features of JSON Schema validation',
+      type: 'object',
+      properties: {
+        booleanTest: {
+          type: 'boolean',
+          default: false,
+        },
+      },
+    };
+
+    const output = triplitJsonFromJsonSchema(
+      jsonSchemaComprensiveTest as JSONSchema7,
+      false
+    );
+
+    expect(output).toEqual({
+      collections: {
+        booleanTest: {
+          schema: {
+            type: 'boolean',
+            options: {},
+          },
+        },
+      },
+      version: 0,
+    });
+  });
+
+  test('if omittedProperties > 0 should show warning', () => {
+    //
+    const jsonSchemaComprensiveTest = {
+      title: 'Comprehensive Test Schema',
+      description:
+        'A schema to test various features of JSON Schema validation',
+      type: 'object',
+      properties: {
+        objectTests: {
+          type: 'object',
+          properties: {
+            objectWithDependencies: {
+              type: 'object',
+              properties: {
+                credit_card: {
+                  type: 'number',
+                },
+                billing_address: {
+                  type: 'string',
+                },
+              },
+              dependencies: {
+                credit_card: ['billing_address'],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const warnSpy = vi.spyOn(console, 'warn');
+
+    const output = triplitJsonFromJsonSchema(
+      jsonSchemaComprensiveTest as JSONSchema7
+    );
+
+    expect(warnSpy).toHaveBeenCalled();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/not supported/i)
+    );
+
+    // restore the original console.warn function
+    warnSpy.mockRestore();
+  });
+
+  test('array constrains should be omitted', () => {
+    //
+    const jsonSchemaComprensiveTest = {
+      title: 'Comprehensive Test Schema',
+      description:
+        'A schema to test various features of JSON Schema validation',
+      type: 'object',
+      properties: {
+        notUniqueArrayTests: {
+          type: 'object',
+          properties: {
+            simpleArray: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+              uniqueItems: true,
+              maxContains: 3,
+            },
+            arrayWithMinItems: {
+              type: 'array',
+              items: {
+                type: 'number',
+              },
+              uniqueItems: true,
+              minItems: 2,
+            },
+          },
+        },
+      },
+    };
+
+    const output = triplitJsonFromJsonSchema(
+      jsonSchemaComprensiveTest as JSONSchema7
+    );
+
+    expect(output).toEqual({
+      collections: {
+        notUniqueArrayTests: {
+          schema: {
+            type: 'record',
+            properties: {
+              simpleArray: {
+                type: 'set',
+                items: {
+                  type: 'string',
+                  options: {},
+                },
+                options: {},
+              },
+              arrayWithMinItems: {
+                type: 'set',
+                items: {
+                  type: 'number',
+                  options: {},
+                },
+                options: {},
+              },
+            },
+            optional: ['arrayWithMinItems', 'simpleArray'],
+          },
+        },
+      },
+      version: 0,
+    });
+  });
+
+  test('normal array type should throw with message', () => {
+    //
+    const jsonSchemaComprensiveTest = {
+      title: 'Comprehensive Test Schema',
+      description:
+        'A schema to test various features of JSON Schema validation',
+      type: 'object',
+      properties: {
+        notUniqueArrayTests: {
+          type: 'object',
+          properties: {
+            simpleArray: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(() => {
+      // debugger;
+      const output = triplitJsonFromJsonSchema(
+        jsonSchemaComprensiveTest as JSONSchema7
+      );
+    }).toThrowError(
+      'Only array types with uniqueItems = true are supported, since Triplit only yet supports set type'
+    );
+  });
+
+  test('tuple array type should throw with message', () => {
+    //
+    const jsonSchemaComprensiveTest = {
+      title: 'Comprehensive Test Schema',
+      description:
+        'A schema to test various features of JSON Schema validation',
+      type: 'object',
+      properties: {
+        notUniqueArrayTests: {
+          type: 'object',
+          properties: {
+            tupleArray: {
+              type: 'array',
+              items: [
+                {
+                  type: 'number',
+                },
+                {
+                  type: 'string',
+                },
+                {
+                  type: 'boolean',
+                },
+              ],
+              additionalItems: false,
+            },
+          },
+        },
+      },
+    };
+
+    expect(() => {
+      // debugger;
+      const output = triplitJsonFromJsonSchema(
+        jsonSchemaComprensiveTest as JSONSchema7
+      );
+    }).toThrowError(
+      'Only array types with uniqueItems = true are supported, since Triplit only yet supports set type'
+    );
+  });
+
+  test('"if / then / else" conditionals should be omitted', () => {
+    //
+    const jsonSchemaComprensiveTest = {
+      title: 'Comprehensive Test Schema',
+      description:
+        'A schema to test various features of JSON Schema validation',
+      type: 'object',
+      properties: {
+        conditionalTest: {
+          type: 'object',
+          properties: {
+            userType: {
+              type: 'string',
+            },
+          },
+          if: {
+            properties: {
+              userType: {
+                const: 'admin',
+              },
+            },
+          },
+          then: {
+            properties: {
+              adminCode: {
+                type: 'string',
+              },
+            },
+            required: ['adminCode'],
+          },
+          else: {
+            properties: {
+              userCode: {
+                type: 'string',
+              },
+            },
+            required: ['userCode'],
+          },
+        },
+      },
+    };
+
+    const output = triplitJsonFromJsonSchema(
+      jsonSchemaComprensiveTest as JSONSchema7
+    );
+
+    expect(output).toEqual({
+      collections: {
+        conditionalTest: {
+          schema: {
+            type: 'record',
+            properties: {
+              userType: {
+                type: 'string',
+                options: {},
+              },
+            },
+            optional: ['userType'],
+          },
+        },
+      },
+      version: 0,
+    });
+  });
+
+  test('"allOf / anyOf / oneOf / not" should error with message', () => {
+    //
+    const jsonSchemaComprensiveTest = {
+      title: 'Comprehensive Test Schema',
+      description:
+        'A schema to test various features of JSON Schema validation',
+      type: 'object',
+      properties: {
+        combinationTests: {
+          type: 'object',
+          properties: {
+            allOfTest: {
+              allOf: [
+                {
+                  type: 'object',
+                  properties: {
+                    name: {
+                      type: 'string',
+                    },
+                  },
+                },
+                {
+                  type: 'object',
+                  properties: {
+                    age: {
+                      type: 'integer',
+                    },
+                  },
+                },
+              ],
+            },
+            anyOfTest: {
+              anyOf: [
+                {
+                  type: 'string',
+                  maxLength: 5,
+                },
+                {
+                  type: 'number',
+                  minimum: 0,
+                },
+              ],
+            },
+            oneOfTest: {
+              oneOf: [
+                {
+                  type: 'number',
+                  multipleOf: 5,
+                },
+                {
+                  type: 'number',
+                  multipleOf: 3,
+                },
+              ],
+            },
+            notTest: {
+              not: {
+                type: 'integer',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(() => {
+      const output = triplitJsonFromJsonSchema(
+        jsonSchemaComprensiveTest as any
+      );
+    }).toThrowError(
+      "Combinations like 'allOf / anyOf / oneOf / not' are not supported by Triplit - please remove them from your JSON data"
+    );
+  });
+
+  test('$ref should throw error', () => {
+    //
+    const jsonSchemaComprensiveTest = {
+      title: 'Comprehensive Test Schema',
+      description:
+        'A schema to test various features of JSON Schema validation',
+      type: 'object',
+      properties: {
+        referencesTest: {
+          type: 'object',
+          properties: {
+            pet: {
+              $ref: '#/definitions/Pet',
+            },
+          },
+        },
+      },
+    };
+
+    expect(() => {
+      const output = triplitJsonFromJsonSchema(
+        jsonSchemaComprensiveTest as JSONSchema7
+      );
+    }).toThrowError(
+      "'$ref' are not supported by Triplit - please remove them from your JSON data"
+    );
+  });
+
+  test('JSON Schema test object should not throw', () => {
+    //
+    const jsonSchemaComprensiveTest = {
+      title: 'Comprehensive Test Schema',
+      description:
+        'A schema to test various features of JSON Schema validation',
+      type: 'object',
+      properties: {
+        stringTests: {
+          type: 'object',
+          properties: {
+            simpleString: {
+              type: 'string',
+            },
+            enumString: {
+              type: 'string',
+              enum: ['red', 'green', 'blue'],
+            },
+            formatEmail: {
+              type: 'string',
+              format: 'email',
+            },
+            formatDate: {
+              type: 'string',
+              format: 'date',
+            },
+          },
+          required: ['simpleString', 'stringWithPattern'],
+        },
+        numberTests: {
+          type: 'object',
+          properties: {
+            integerType: {
+              type: 'integer',
+            },
+            numberType: {
+              type: 'number',
+            },
+            integerEnum: {
+              type: 'integer',
+              enum: [1, 2, 3, 5, 8],
+            },
+          },
+        },
+        booleanTest: {
+          type: 'boolean',
+        },
+        nullTest: {
+          type: 'null',
+        },
+        arrayTests: {
+          type: 'object',
+          properties: {
+            arrayWithUniqueItems: {
+              type: 'array',
+              items: {
+                type: 'integer',
+              },
+              uniqueItems: true,
+            },
+          },
+        },
+        objectTests: {
+          type: 'object',
+          properties: {
+            simpleObject: {
+              type: 'object',
+              properties: {
+                name: {
+                  type: 'string',
+                },
+                age: {
+                  type: 'integer',
+                },
+              },
+              required: ['name'],
+            },
+            objectWithDependencies: {
+              type: 'object',
+              properties: {
+                credit_card: {
+                  type: 'number',
+                },
+                billing_address: {
+                  type: 'string',
+                },
+              },
+              dependencies: {
+                credit_card: ['billing_address'],
+              },
+            },
+          },
+        },
+      },
+      required: ['stringTests', 'numberTests', 'booleanTest', 'arrayTests'],
+      definitions: {
+        Pet: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+            },
+            age: {
+              type: 'integer',
+            },
+            species: {
+              type: 'string',
+              enum: ['dog', 'cat', 'fish'],
+            },
+          },
+          required: ['name', 'species'],
+        },
+      },
+    };
+
+    expect(() => {
+      const output = triplitJsonFromJsonSchema(
+        jsonSchemaComprensiveTest as JSONSchema7
+      );
+    }).not.toThrow();
+  });
+});
+
+describe('Additional Compatibility Tests (partially from LLM claude sonnet 3.5 generation, but heavily corrected)', () => {
+  test('Complex nested structures', () => {
+    const complexNestedSchema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        level1: {
+          type: 'object',
+          properties: {
+            level2: {
+              type: 'object',
+              properties: {
+                level3: {
+                  type: 'object',
+                  properties: {
+                    name: { type: 'string' },
+                    value: { type: 'number' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = triplitJsonFromJsonSchema(complexNestedSchema);
+    expect(result?.collections.level1.schema.type).toBe('record');
+    expect(result?.collections.level1.schema.properties.level2.type).toBe(
+      'record'
+    );
+    expect(
+      result?.collections.level1.schema.properties.level2.properties.level3.type
+    ).toBe('record');
+  });
+
+  test('Triplit Set can only hold primitives/scalars, not objects/records', () => {
+    const arrayWithObjs: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        arrayObject: {
+          type: 'array',
+          uniqueItems: true,
+          items: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              value: { type: 'number' },
+            },
+          },
+        },
+      },
+    };
+
+    expect(() => {
+      triplitJsonFromJsonSchema(arrayWithObjs);
+    }).toThrowError(
+      "Arrays that hold objects or tuples are not supported, as Triplit's Set can only have primitives - please remove them from your JSON data"
+    );
+  });
+
+  test('String formats', () => {
+    const stringFormatsSchema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        dateTime: { type: 'string', format: 'date-time' },
+        uri: { type: 'string', format: 'uri' },
+        ipv4: { type: 'string', format: 'ipv4' },
+        ipv6: { type: 'string', format: 'ipv6' },
+        regularString: { type: 'string' },
+      },
+    };
+
+    const result = triplitJsonFromJsonSchema(stringFormatsSchema);
+    expect(result?.collections.dateTime.schema.type).toBe('date');
+    expect(result?.collections.uri.schema.type).toBe('string');
+    expect(result?.collections.uri.schema.format).toBe('uri');
+    expect(result?.collections.ipv4.schema.type).toBe('string');
+    expect(result?.collections.ipv4.schema.format).toBe('ipv4');
+    expect(result?.collections.ipv6.schema.type).toBe('string');
+    expect(result?.collections.ipv6.schema.format).toBe('ipv6');
+    expect(result?.collections.regularString.schema.type).toBe('string');
+  });
+
+  test('Number constraints', () => {
+    const numberConstraintsSchema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        exclusiveMinMax: {
+          type: 'number',
+          exclusiveMinimum: 0,
+          exclusiveMaximum: 100,
+        },
+      },
+    };
+
+    // expect(() => {
+    //   triplitJsonFromJsonSchema(numberConstraintsSchema);
+    // }).toThrowError(
+    //   'JSON number constraints ("6.2. Validation Keywords for Numeric Instances (number and integer)") are not supported by Triplit - please remove them from your JSON data'
+    // );
+
+    const output = triplitJsonFromJsonSchema(
+      numberConstraintsSchema as JSONSchema7
+    );
+
+    expect(output).toEqual({
+      collections: {
+        exclusiveMinMax: {
+          schema: {
+            type: 'number',
+            options: {},
+          },
+        },
+      },
+      version: 0,
+    });
+  });
+
+  test('Number constraints 2', () => {
+    const numberConstraintsSchema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        numberWithMultipleOf: {
+          type: 'number',
+          multipleOf: 0.5,
+        },
+        numberWithRange: {
+          type: 'number',
+          minimum: 0,
+          maximum: 100,
+        },
+      },
+    };
+
+    // expect(() => {
+    //   triplitJsonFromJsonSchema(numberConstraintsSchema);
+    // }).toThrowError(
+    //   'JSON number constraints ("6.2. Validation Keywords for Numeric Instances (number and integer)") are not supported by Triplit - please remove them from your JSON data'
+    // );
+
+    const output = triplitJsonFromJsonSchema(
+      numberConstraintsSchema as JSONSchema7
+    );
+
+    expect(output).toEqual({
+      collections: {
+        numberWithMultipleOf: {
+          schema: {
+            type: 'number',
+            options: {},
+          },
+        },
+        numberWithRange: {
+          schema: {
+            type: 'number',
+            options: {},
+          },
+        },
+      },
+      version: 0,
+    });
+  });
+
+  test('Date: not supported formats', () => {
+    const numberConstraintsSchema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        dateTime: {
+          type: 'string',
+          format: 'time',
+        },
+        dateDuration: {
+          type: 'string',
+          format: 'duration',
+        },
+      },
+    };
+
+    expect(() => {
+      triplitJsonFromJsonSchema(numberConstraintsSchema);
+    }).toThrowError(
+      'date formats "time" and "duration" are not supported by Triplit - please remove them from your JSON data'
+    );
+  });
+
+  describe('const not supported', () => {
+    test('const not supported', () => {
+      //
+      const jsonSchemaComprensiveTest = {
+        type: 'object',
+        properties: {
+          constNumber: { type: 'number', const: 42 },
+        },
+      };
+
+      expect(() => {
+        triplitJsonFromJsonSchema(jsonSchemaComprensiveTest as JSONSchema7);
+      }).toThrowError(
+        'const type is not supported by Triplit - please remove them from your JSON data'
+      );
+    });
+
+    test('any const named key should pass', () => {
+      //
+      const jsonSchemaComprensiveTest = {
+        type: 'object',
+        properties: {
+          const: { type: 'number' },
+        },
+      };
+
+      expect(() => {
+        triplitJsonFromJsonSchema(jsonSchemaComprensiveTest as JSONSchema7);
+      }).not.toThrow();
+    });
+  });
+
+  test('Array and Set constraints', () => {
+    const arraySchema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        uniqueArray: {
+          type: 'array',
+          uniqueItems: true,
+          items: { type: 'string' },
+          minItems: 2,
+          maxItems: 5,
+        },
+        regularArray: {
+          type: 'array',
+          items: { type: 'number' },
+          minItems: 1,
+          maxItems: 10,
+          uniqueItems: true,
+        },
+      },
+    };
+
+    // expect(() => {
+    //   triplitJsonFromJsonSchema(arraySchema);
+    // }).toThrowError(
+    //   'JSON array constraints ("6.4. Validation Keywords for Arrays") are not supported by Triplit - please remove them from your JSON data'
+    // );
+
+    const output = triplitJsonFromJsonSchema(arraySchema as JSONSchema7);
+
+    expect(output).toEqual({
+      collections: {
+        uniqueArray: {
+          schema: {
+            type: 'set',
+            items: {
+              type: 'string',
+              options: {},
+            },
+            options: {},
+          },
+        },
+        regularArray: {
+          schema: {
+            type: 'set',
+            items: {
+              type: 'number',
+              options: {},
+            },
+            options: {},
+          },
+        },
+      },
+      version: 0,
+    });
+  });
+
+  test('type object requires properties', () => {
+    const objectSchema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        subObject: {
+          type: 'object',
+          // properties: {},
+        },
+      },
+    };
+
+    const result = expect(() =>
+      triplitJsonFromJsonSchema(objectSchema)
+    ).toThrowError(
+      'each type object requires a properties field for Triplit Schema to process it'
+    );
+  });
+
+  test('Object constraints', () => {
+    const objectSchema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        constrainedObject: {
+          type: 'object',
+          minProperties: 1,
+          maxProperties: 5,
+          properties: {},
+        },
+      },
+    };
+
+    // expect(() => {
+    //   const output = triplitJsonFromJsonSchema(objectSchema);
+    // }).toThrowError(
+    //   'JSON object constraints ("6.5. Validation Keywords for Objects") are not supported by Triplit - please remove them from your JSON data'
+    // );
+
+    const output = triplitJsonFromJsonSchema(objectSchema);
+
+    expect(output).toEqual({
+      collections: {
+        constrainedObject: {
+          schema: {
+            type: 'record',
+            properties: {},
+          },
+        },
+      },
+      version: 0,
+    });
+  });
+
+  test('string constraints', () => {
+    const jsonSchemaComprensiveTest: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        stringTests: {
+          type: 'object',
+          properties: {
+            simpleString: {
+              type: 'string',
+            },
+            stringWithMinLength: {
+              type: 'string',
+              minLength: 5,
+            },
+            stringWithMaxLength: {
+              type: 'string',
+              maxLength: 10,
+            },
+            stringWithPattern: {
+              type: 'string',
+              pattern: '^[A-Z][a-z]+$',
+            },
+            enumString: {
+              type: 'string',
+              enum: ['red', 'green', 'blue'],
+            },
+            formatEmail: {
+              type: 'string',
+              format: 'email',
+            },
+            formatDate: {
+              type: 'string',
+              format: 'date',
+            },
+          },
+        },
+      },
+    };
+
+    // expect(() => {
+    //   triplitJsonFromJsonSchema(jsonSchemaComprensiveTest);
+    // }).toThrowError(
+    //   'JSON string constraints (" 6.3. Validation Keywords for Strings ") are not supported by Triplit - please remove them from your JSON data'
+    // );
+
+    const output = triplitJsonFromJsonSchema(
+      jsonSchemaComprensiveTest as JSONSchema7
+    );
+
+    expect(output).toEqual({
+      collections: {
+        stringTests: {
+          schema: {
+            type: 'record',
+            properties: {
+              simpleString: {
+                type: 'string',
+                options: {},
+              },
+              stringWithMinLength: {
+                type: 'string',
+                options: {},
+              },
+              stringWithMaxLength: {
+                type: 'string',
+                options: {},
+              },
+              stringWithPattern: {
+                type: 'string',
+                options: {},
+              },
+              enumString: {
+                type: 'string',
+                options: {
+                  enum: ['red', 'green', 'blue'],
+                },
+              },
+              formatEmail: {
+                type: 'string',
+                format: 'email',
+                options: {},
+              },
+              formatDate: {
+                options: {},
+                type: 'date',
+              },
+            },
+            optional: [
+              'enumString',
+              'formatDate',
+              'formatEmail',
+              'simpleString',
+              'stringWithMaxLength',
+              'stringWithMinLength',
+              'stringWithPattern',
+            ],
+          },
+        },
+      },
+      version: 0,
+    });
+  });
+
+  test('Null type handling', () => {
+    const nullableSchema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        nullableString: { type: ['string', 'null'] },
+        nullType: { type: 'null' },
+      },
+    };
+
+    const result = triplitJsonFromJsonSchema(nullableSchema);
+    expect(result?.collections.nullableString.schema.type).toBe('string');
+    expect(result?.collections.nullableString.schema.options.nullable).toBe(
+      true
+    );
+    expect(result?.collections.nullType.schema.type).toBe('string');
+    expect(result?.collections.nullType.schema.options.nullable).toBe(true);
+    expect(result?.collections.nullType.schema.options.default).toBe(null);
+  });
+
+  test('Default value handling', () => {
+    const defaultValueSchema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        stringWithDefault: { type: 'string', default: 'default value' },
+        uuidField: { type: 'string', default: 'uuid' },
+        dateField: { type: 'string', format: 'date-time', default: 'now' },
+      },
+    };
+
+    const result = triplitJsonFromJsonSchema(defaultValueSchema);
+    expect(result?.collections.stringWithDefault.schema.options.default).toBe(
+      'default value'
+    );
+    expect(result?.collections.uuidField.schema.options.default).toEqual({
+      func: 'uuid',
+      args: null,
+    });
+    expect(result?.collections.dateField.schema.options.default).toEqual({
+      func: 'now',
+      args: null,
+    });
+  });
+
+  test('Enum handling', () => {
+    const enumSchema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        enumField: { type: 'string', enum: ['a', 'b', 'c'] },
+      },
+    };
+
+    const result = triplitJsonFromJsonSchema(enumSchema);
+    expect(result?.collections.enumField.schema.options.enum).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+
+  test('Required fields conversion', () => {
+    const jsonSchemaComprensiveTest = {
+      title: 'Comprehensive Test Schema',
+      description:
+        'A schema to test various features of JSON Schema validation',
+      type: 'object',
+      properties: {
+        requiredToOptionalField: {
+          type: 'object',
+          properties: {
+            requiredField: { type: 'string' },
+            optionalField: { type: 'number' },
+          },
+          required: ['requiredField'],
+        },
+      },
+    };
+
+    const result = triplitJsonFromJsonSchema(
+      jsonSchemaComprensiveTest as JSONSchema7
+    );
+
+    expect(result?.collections.requiredToOptionalField.schema.optional).toEqual(
+      ['optionalField']
+    );
+  });
+
+  test('Unicode handling', () => {
+    const unicodeSchema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        日本語: { type: 'string' },
+        Français: { type: 'number' },
+        Русский: { type: 'boolean' },
+      },
+    };
+
+    const result = triplitJsonFromJsonSchema(unicodeSchema);
+    expect(result?.collections['日本語'].schema.type).toBe('string');
+    expect(result?.collections['Français'].schema.type).toBe('number');
+    expect(result?.collections['Русский'].schema.type).toBe('boolean');
+  });
+
+  test('Error handling for unsupported features', () => {
+    const unsupportedSchemas = [
+      {
+        type: 'object',
+        properties: {
+          patternProp: {
+            type: 'object',
+            patternProperties: {
+              '^S_': { type: 'string' },
+            },
+          },
+        },
+      },
+      {
+        type: 'object',
+        properties: {
+          conditional: {
+            if: { properties: { a: { type: 'string' } } },
+            then: { properties: { b: { type: 'number' } } },
+            else: { properties: { c: { type: 'boolean' } } },
+          },
+        },
+      },
+      {
+        type: 'object',
+        properties: {
+          combined: {
+            allOf: [
+              { properties: { a: { type: 'string' } } },
+              { properties: { b: { type: 'number' } } },
+            ],
+          },
+        },
+      },
+      {
+        type: 'object',
+        properties: {
+          ref: {
+            $ref: '#/definitions/SomeDefinition',
+          },
+        },
+      },
+    ];
+
+    unsupportedSchemas.forEach((schema, index) => {
+      expect(() => triplitJsonFromJsonSchema(schema as any)).toThrow();
+    });
+  });
+
+  test('Performance with large schema', () => {
+    const largeSchema: JSONSchema7 = {
+      type: 'object',
+      properties: Object.fromEntries(
+        Array.from({ length: 1000 }, (_, i) => [
+          `field${i}`,
+          { type: 'string' },
+        ])
+      ),
+    };
+
+    const startTime = performance.now();
+    const result = triplitJsonFromJsonSchema(largeSchema);
+    const endTime = performance.now();
+
+    expect(result).toBeDefined();
+    expect(Object.keys(result?.collections || {}).length).toBe(1000);
+    expect(endTime - startTime).toBeLessThan(1000); // Assuming less than 1 second is acceptable
+  });
+
+  test('custom error has details object for debugging', () => {
+    // try {
+    //   triplitJsonFromJsonSchema(
+    //     exampleTestOfjsonSchemaFromZodSchema as JSONSchema7
+    //   );
+    // } catch (err) {
+    //   // debugger;
+    // }
+    try {
+      triplitJsonFromJsonSchema({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: {
+          // TODO: write test for empty objects?
+          unknown: {},
+        },
+        additionalProperties: false,
+        // add test? no, this is not valid json schema
+        // default: {
+        //   string: 'hello',
+        // },
+        description: 'watup',
+      } as JSONSchema7);
+      // debugger;
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect(err.details).toBeDefined(); // Check that `details` exists
+    }
+  });
+});
+
+describe('Compatibility against real JSONSchemas', () => {
+  test('Zod JsonSchema Export (from zodToJsonSchema)', () => {
+    // try {
+    //   triplitJsonFromJsonSchema(
+    //     exampleTestOfjsonSchemaFromZodSchema as JSONSchema7
+    //   );
+    // } catch (err) {
+    //   // debugger;
+    // }
+    expect(() =>
+      triplitJsonFromJsonSchema(
+        exampleTestOfjsonSchemaFromZodSchema as JSONSchema7
+      )
+    ).not.toThrow();
+  });
+});
+
+function duplicateWithoutAncestorsWithKey(obj: any, keyToOmit: string) {
+  // Check if the key exists in the current object
+  if (keyToOmit in obj) {
+    return null; // Return null to indicate this object should be omitted
+  }
+
+  // Create a new object to hold the filtered result
+  const result: any = {};
+
+  for (const key in obj) {
+    const value = obj[key];
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      Array.isArray(value) === false &&
+      key !== 'options'
+      // original keeps empty options obj
+    ) {
+      const nestedResult = duplicateWithoutAncestorsWithKey(value, keyToOmit);
+      // Only add the nested result if it's not null
+      if (nestedResult !== null) {
+        result[key] = nestedResult;
+      }
+    } else {
+      result[key] = value; // Add primitive values directly
+    }
+  }
+
+  // Return the result if there are any keys left, otherwise return null
+  return Object.keys(result).length > 0 ? result : null;
+}

--- a/packages/db/test/db/import/json-schema/triplit-json-from-json-schema.spec.ts
+++ b/packages/db/test/db/import/json-schema/triplit-json-from-json-schema.spec.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test, vi } from 'vitest';
 
-import { triplitJsonFromJsonSchema } from '../../../../src/schema/import/json-schema/triplit-json-from-json-schema';
-import { exportSchemaAsJSONSchema } from '../../../../src/schema/export/json-schema/export';
 import { schema as exhaustiveTestTriplitSchema } from '../../export/exhaustive-test-schema';
 
-import { schemaToJSON } from '../../../../src/schema/export';
+import {
+  schemaToJSON,
+  exportSchemaAsJSONSchema,
+  triplitJsonFromJsonSchema,
+} from '../../../../src/';
 import { JSONSchema7 } from 'json-schema';
 import { exampleTestOfjsonSchemaFromZodSchema } from './exampleTestOfjsonSchemaFromZodSchema';
 


### PR DESCRIPTION
Generate TriplitSchema from JSON Schema.

### Unlocks
- import from other (db schemas) to triplit
- generation of TriplitSchema as an artifact
- ability for upstream tooling integration
- opens up the Triplit ecosystem

### How it works
A transformation pipeline is applied to the **JSON Schema** to transform it into valid **Triplit JSON Schema**. The output is also validated against **JSONToSchema** to ensure compliance.

- Constraints that can not be parsed by Triplit will be omitted (with a console.warn message).
- Data types that have no equivalent in Triplit (e.g. pure array) will throw an error.