### PR TITLE
doc: corrected vue example

### DIFF
--- a/packages/docs/src/pages/frameworks/vue.mdx
+++ b/packages/docs/src/pages/frameworks/vue.mdx
@@ -91,7 +91,7 @@ const {
 The `useConnectionStatus` hook subscribes to changes to the connection status of the client and will automatically unsubscribe when the component unmounts.
 
 ```vue filename="ConnectionStatus.vue"
-<script lang="ts">
+<script setup lang="ts">
 import { useConnectionStatus } from '@triplit/vue';
 import { client } from './triplit';
 


### PR DESCRIPTION
This update corrects a missing setup function in the script tag of a Vue component that uses the Composition API. The setup function is mandatory when utilizing the Composition API, and its absence would cause issues when copy pasting this component into a demo project.