### PR TITLE
Update "Build a Todos app with React, Vite and Triplit" tutorial

### DIFF
--- a/packages/docs/src/pages/react-tutorial.mdx
+++ b/packages/docs/src/pages/react-tutorial.mdx
@@ -133,11 +133,9 @@ Make sure you have `.env` as part of your `.gitignore` file:
 
 Now restart the development server by pressing `Ctrl + C` and running `npx triplit dev` again.
 
-We're basically done setting up Triplit. Now we can push the schema and start building the app.
+We're basically done setting up Triplit. Now we can start building the app.
 
-### Push the schema
-
-Run `npx triplit schema push` to make the triplit server aware of the schema you've defined.
+Note: The dev server automatically picks up on schema changes. If you're using Triplit Cloud, run `npx triplit schema push` to make the triplit server aware of the schema you've defined.
 
 ## Building the app
 


### PR DESCRIPTION
The `Build a Todos app with React, Vite and Triplit` tutorial was missing a step. This PR adds it. 