### PR TITLE
fix: replace TextEncoder with Buffer to ensure jwtVerify accepts key

### DIFF
--- a/packages/server-core/src/token.ts
+++ b/packages/server-core/src/token.ts
@@ -43,7 +43,7 @@ async function getJwtKey(rawPublicKey: string): Promise<KeyLike | Uint8Array> {
   if (parsedKey) {
     return importJWK(parsedKey, 'RS256');
   }
-  return new TextEncoder().encode(rawPublicKey);
+  return new Uint8Array(Buffer.from(rawPublicKey));
 }
 
 export async function parseAndValidateToken(


### PR DESCRIPTION
This PR fixes the following error when using triplit.startSession() with jsonwebtoken-signed tokens:
```
The signature on your token could not be verified successfully. | Context: Key for the HS256 algorithm must be one of type KeyObject, CryptoKey, or Uint8Array. Received an instance of Uint8Array  
```

The issue was caused by TextEncoder().encode(secret) producing a Uint8Array that fails internal checks in jose.jwtVerify() in some environments (e.g. Vitest).

### Repro:
```javascript
const token = jwt.sign({ sub: 'user-johndoe' }, 'mysecret')
triplit.startSession(token)
await triplit.fetchOne(triplit.query('users'), {policy: 'remote-only'})
```

### Fix
TextEncoder().encode(...) was replaced with new Uint8Array(Buffer.from(secret)), which works reliably across environments.